### PR TITLE
Fix readme for go get git-checkout-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Visit the [releases](https://github.com/teddywing/git-checkout-history/releases)
 ### Installing From Source
 Run these commands to build `git-checkout-history` and `git-checkout-store`:
 
-	$ go get github.com/teddywing/git-checkout-history
+	$ go get github.com/teddywing/git-checkout-history/...
 	$ go install github.com/teddywing/git-checkout-history/git-checkout-history
 	$ go install github.com/teddywing/git-checkout-history/git-checkout-store
 


### PR DESCRIPTION
This is what I needed to do in order to checkout this repository locally.

I also used nix-shell, so I set my GOPATH to ~/go from inside the nix-shell environment.